### PR TITLE
Potential fix for matchmode waiting for players bug

### DIFF
--- a/code/game/g_main.c
+++ b/code/game/g_main.c
@@ -1009,7 +1009,7 @@ void CalculateRanks( void ) {
 			level.sortedClients[level.numConnectedClients] = i;
 			level.numConnectedClients++;
 
-			if ( level.clients[i].sess.sessionTeam != Q3F_TEAM_SPECTATOR && level.clients[i].ps.persistant[PERS_CURRCLASS] != Q3F_CLASS_NULL ) {
+			if ( level.clients[i].sess.sessionTeam != Q3F_TEAM_SPECTATOR ) {
 				level.numNonSpectatorClients++;
 				if ( level.clients[i].pers.connected == CON_CONNECTED ) {
 					level.numPlayingClients++;


### PR DESCRIPTION
This PR is an attempt to fix the matchmode "waiting for players" round 2 bug, under the assumption that upon map restart in matchmode if classes are null then they aren't counted properly in the required match player count