### PR TITLE
Potential fix for flametroopers obituary messages not showing the attackers name

### DIFF
--- a/code/cgame/cg_event.c
+++ b/code/cgame/cg_event.c
@@ -452,14 +452,17 @@ static void CG_Obituary( entityState_t *ent, qboolean isally ) {
 		}
 		break;
 	case MOD_FLAME:
-		/* Ensiform - Added for misc_flamethrower */
-		r = rand() % 5;
-		switch(r) {
-	case 0:	message = "was caramelized"; break;
-	case 1:	message = "was cooked to 'well done'"; break;
-	case 2:	message = "was burnt to a crisp"; break;
-	case 3:	message = "was deep fried without batter"; break;
-	case 4:	message = "was set ablaze"; break;
+		if (attacker == ENTITYNUM_WORLD) // Check attacker so that we don't set this obituary message on player kills, preventing the actual player kill message from being set below
+		{
+			/* Ensiform - Added for misc_flamethrower */
+			r = rand() % 5;
+			switch(r) {
+		case 0:	message = "was caramelized"; break;
+		case 1:	message = "was cooked to 'well done'"; break;
+		case 2:	message = "was burnt to a crisp"; break;
+		case 3:	message = "was deep fried without batter"; break;
+		case 4:	message = "was set ablaze"; break;
+			}
 		}
 		break;
 	case MOD_TARGET_LASER:


### PR DESCRIPTION
This PR makes it so obituaries from MOD_FLAME check the attacker so that the message isn't set prematurely, preventing the message with the attacker's name from being set later.

There is a case to be made for putting this entire switch statement (starting at ln 399) below the if statement on 654, and checking if message has been set, as this issue could arise again if for example a player caused a death by one of the other cases in the switch such as MOD_BEAM etc.

Unable to test by myself unfortunately