### PR TITLE
antilag: enable by default

### DIFF
--- a/code/cgame/cg_local.h
+++ b/code/cgame/cg_local.h
@@ -1404,6 +1404,7 @@ typedef struct {
 	char			voteString[MAX_STRING_TOKENS];
 
 	int				levelStartTime;
+	int			antilag_ms;
 
 	qboolean		newHud;
 

--- a/code/cgame/cg_localents.c
+++ b/code/cgame/cg_localents.c
@@ -948,7 +948,8 @@ static int num_predicted_ents;
 
 static inline int CG_PredictedMissilesEnabled() {
 	// Not yet default enabled.  Needs antilag on and prediction on.
-	return (cg_predictWeapons.integer & 2) && (cg_unlagged.integer & 2);
+	// TODO: Cap prediction to antilag_ms
+	return cg_predictWeapons.integer && cg_unlagged.integer && cgs.antilag_ms;
 }
 
 static void CG_UntrackPredictedEnt(localEntity_t *le) {
@@ -993,7 +994,7 @@ void CG_MatchPredictedEnt(centity_t* cent) {
 			match->angles.trTime += cg.time;
 
 		if (cg_predictWeapons.integer & 4)
-			printf("BEST MATCH: %0.2f [%0.1fms] [age=%dms] [%d]\n",
+			Com_Printf("BEST MATCH: %0.2f [%0.1fms] [age=%dms] [%d]\n",
 					dist, 1000 * dist / VectorLength(match->pos.trDelta),
 					match->angles.trTime, num_predicted_ents);
 

--- a/code/cgame/cg_servercmds.c
+++ b/code/cgame/cg_servercmds.c
@@ -201,8 +201,8 @@ void CG_ParseServerinfo( void ) {
 	cg.teamScores[2] = atoi( Info_ValueForKey( info, "score_yellow" ) );
 	cg.teamScores[3] = atoi( Info_ValueForKey( info, "score_green" ) );
 
-	// we'll need this for deciding whether or not to predict weapon effects
 	cgs.unlagged = atoi( Info_ValueForKey( info, "g_unlagged" ) );
+	cgs.antilag_ms = atoi( Info_ValueForKey( info, "g_antilag_ms" ) );
 }
 
 void CG_ParseSysteminfo( void ) {

--- a/code/game/g_cvar.h
+++ b/code/game/g_cvar.h
@@ -222,6 +222,7 @@ G_CVAR( g_debugBullets, "g_debugBullets", "0", CVAR_CHEAT, qfalse )
 	//Unlagged related 
 G_CVAR( g_smoothClients, "g_smoothClients", "1", CVAR_ARCHIVE, qfalse )
 G_CVAR( g_unlagged, "g_unlagged", "1", CVAR_ARCHIVE | CVAR_SERVERINFO, qtrue )
+G_CVAR( g_antilag_ms, "g_antilag_ms", "150", CVAR_ARCHIVE | CVAR_SERVERINFO, qtrue )
 G_CVAR( g_experiment, "g_experiment", "1", CVAR_ARCHIVE | CVAR_SERVERINFO, qtrue )
 //G_CVAR( g_unlaggedVersion, "g_unlaggedVersion", "2.0", CVAR_ROM | CVAR_SERVERINFO, qfalse )
 

--- a/code/game/g_missile.c
+++ b/code/game/g_missile.c
@@ -477,7 +477,7 @@ void G_RunMissileTime( gentity_t *ent, int time ) {
 void G_RunMissile( gentity_t *ent ) {
 	if (ent->antilag_time) {
 		const int kStep = 10;
-		int time = Q_max(level.time - 150, ent->antilag_time);
+		int time = Q_max(level.time - g_antilag_ms.integer, ent->antilag_time);
 		int end = level.time - kStep;
 		qboolean ran = qfalse;
 
@@ -494,6 +494,7 @@ void G_RunMissile( gentity_t *ent ) {
 			if (ran)
 				G_UnTimeShiftAllClients(ent->parent);
 		}
+
 		ent->antilag_time = 0;
 	}
 
@@ -768,7 +769,7 @@ gentity_t *fire_rocket (gentity_t *self, vec3_t start, vec3_t dir) {
 
 	// need to check for client being valid, as this can be a shooter_rocket
 	// there is also shooter_grenade if fire_grenade gets this too eventually
-	if (self->client && self->client->pers.unlagged & 2)
+	if (self->client && self->client->pers.unlagged)
 		bolt->antilag_time = self->client->attackTime;
 
 	return bolt;
@@ -822,7 +823,7 @@ gentity_t *fire_nail (gentity_t *self, vec3_t start, vec3_t dir, int damage, int
 	SnapVector( bolt->s.pos.trDelta );			// save net bandwidth
 	VectorCopy (start, bolt->r.currentOrigin);
 
-	if (self->client && self->client->pers.unlagged & 2)
+	if (self->client && self->client->pers.unlagged)
 		bolt->antilag_time = self->client->attackTime;
 
 	return bolt;

--- a/code/game/g_q3f_weapon.c
+++ b/code/game/g_q3f_weapon.c
@@ -542,7 +542,7 @@ void Weapon_Napalm_Fire(struct gentity_s *ent) {
 		bolt->s.powerups = (1 << PW_QUAD);
 	}
 
-	if (ent->client && ent->client->pers.unlagged & 2)
+	if (ent->client && ent->client->pers.unlagged)
 		bolt->antilag_time = ent->client->attackTime;
 
 	ent->client->pers.stats.data[STATS_WP + WP_NAPALMCANNON].shots++;
@@ -1099,8 +1099,9 @@ void G_Q3F_DetPipe(struct gentity_s *self, qboolean antilag)
 	struct gentity_s *ent = NULL;
 	int timeindex = level.time;
 
-	antilag = antilag && g_unlagged.integer && g_experiment.integer;
+	antilag = antilag && g_unlagged.integer;
 
+	// Note: does not yet respect g_antilag_ms
 	if (antilag)
 		timeindex = G_DoTimeShiftFor(self);
 


### PR DESCRIPTION
can now be disabled by: `set g_antilag_ms 0`
at some point should rectify with legacy g_antilag