### PR TITLE
Add a "countdown" type to panel_timer entity

### DIFF
--- a/code/cgame/cg_q3f_panel.c
+++ b/code/cgame/cg_q3f_panel.c
@@ -838,6 +838,13 @@ static int CG_Q3F_PanelFuncTimer(void)
 							panelTimerRTC * 0.0001 <= 11 ? "AM" : "PM" );
 				size = 11;
 				break;
+		case 8: // Countdown timer that starts when an entity targets this, using that entities wait timer
+				if ((msec = cent->currentState.angles2[0] * 1000 - (cg.time - cent->currentState.angles2[2])) < 0)
+					msec = 0;
+				// This one is too important to blink, also strip the leading "00" if it's below a minute
+				str = va("%s%s%02d", (float)(msec / 60000) >= 1.f ? va("%02d", msec / 60000) : "", ":", (msec / 1000) % 60);
+				size = 5;
+				break;
 		default:	// No timer type.
 				str = "";
 				size = 1;

--- a/code/game/g_q3f_panel.c
+++ b/code/game/g_q3f_panel.c
@@ -420,6 +420,13 @@ void G_Q3F_PanelMessageThink( gentity_t *ent )
 	ent->nextthink = level.time + FRAMETIME;
 }
 
+void G_PanelTimer_Use(gentity_t* self, gentity_t* other, gentity_t* activator)
+{
+	// angles2[0] is the actual timer, [1] is the time to set to, and [2] is the level time the timer was set
+	self->s.angles2[0] = self->s.angles2[1];
+	self->s.angles2[2] = level.time;
+}
+
 
 
 
@@ -472,9 +479,11 @@ void SP_Q3F_Panel_Timer( gentity_t *self )
 	if( !G_Q3F_PanelBaseSpawn( self ) )
 		return;
 
-	self->s.time2 = G_Q3F_ConvertSpawnColour( "color", "1.0 0.0 0.0" );
+	self->s.time2 = G_Q3F_ConvertSpawnColour( "color", "1.0 1.0 1.0" ); // TODO: convert to kvp param?
 	G_SpawnInt( "type", "1", &self->s.otherEntityNum );
+	G_SpawnFloat("wait", "30", &self->s.angles2[1]); // angles2[0] is the actual timer, [1] is the time to set to, and [2] is the level time the timer was set
 
+	self->use = G_PanelTimer_Use;
 	self->s.groundEntityNum	= Q3F_PANELTYPE_TIMER;
 }
 


### PR DESCRIPTION
This PR adds a new "type" (type 8) to panel_timer that makes it so when it receives a target input from another entity (i.e. a func_button) it begins a countdown equal to it's "wait" key parameter.

I made it so if it's under a minute, it strips the trailing "00", so it prints only ":xx". I also disabled the blinking effect that the other panel_timer types exhibit since it seemed distracting for something that could be considered important to the gameplay.

I also recolored panel_timers to have white text as red text seems odd considering it's one of our primary team colors, let me know if you'd like me to only recolor the countdown type instead.

Demonstration: https://medal.tv/games/requested/clips/kAJjcmjMN37_DMJro?invite=cr-MSxqaUEsNjgyNTcwODI

![image](https://github.com/user-attachments/assets/60ba4a3e-50ca-41eb-81bc-26835def79c3)
