### PR TITLE
Nailbomb nail travel duration nerf

### DIFF
--- a/code/cgame/cg_q3f_grenades.c
+++ b/code/cgame/cg_q3f_grenades.c
@@ -335,11 +335,11 @@ static int NailEndTime( struct gnail *nail, float zpos, int parentnum )
 	end[0] = nail->xvel;
 	end[1] = nail->yvel;
 	end[2] = 0;
-	VectorScale( end, 20000 * Q3F_NAILSPEED / 1000 , end );		// 20 seconds travel
+	VectorScale( end, 500 * Q3F_NAILSPEED / 1000 , end );		// 20 seconds travel - Default; Tulkas - adjusted to 1 second travel duration to reduce nail spam
 	VectorAdd( start, end, end );
 
 	CG_Trace( &tr, start, NULL, NULL, end, parentnum, MASK_SHOT );
-	return( nail->starttime + 20000 * tr.fraction );
+	return( nail->starttime + 500 * tr.fraction );
 }
 
 static int InitNailArray( centity_t *cent )

--- a/code/game/g_q3f_grenades.c
+++ b/code/game/g_q3f_grenades.c
@@ -915,6 +915,12 @@ static void NailThink( gentity_t *grenade )
 		ptr = array + index;
 		if( !ptr->starttime || ptr->starttime > level.time )
 			continue;
+		if( level.time - ptr->starttime >= 500 )
+		{
+			ptr->starttime = 0; // expire nail
+			*(bitptr + (index>>3)) &= ~(1<<(index&7)); // tell client it's gone
+			continue;
+		}
 		start[0]	= ptr->xpos;
 		start[1]	= ptr->ypos;
 		start[2]	= grenade->r.currentOrigin[2];


### PR DESCRIPTION
reduced nail travel time to .5 seconds to reduce nail spam and reward accuracy for throwing nailbombs at players/sentries.

This will cut down on stray nails stopping players across the map or clearning entire rooms just because a nailbomb was panic-tossed into a room. will also cut down on defensive soldiers accidentally killing teammates with stray nails.